### PR TITLE
exec for windows

### DIFF
--- a/lib/runcoderun-view.coffee
+++ b/lib/runcoderun-view.coffee
@@ -64,7 +64,7 @@ class RunCodeRunView extends ScrollView
     @trigger 'title-changed'
 
     # Run file
-    exec "'#{@filePath}'", (error, stdout, stderr) =>
+    exec "\"#{@filePath}\"", (error, stdout, stderr) =>
       # "Map" execution error to stderr
       stderr += error if error?
       # Render output


### PR DESCRIPTION
on windows, exec needs double quotes rather than single quotes
